### PR TITLE
Add Dockerfile and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:latest as builder
+
+# If RELEASE is not passed as a build arg, go with master
+ARG RELEASE=master
+WORKDIR /go
+ENV GOBIN $GOPATH/bin
+RUN echo "Using Hacher ${RELEASE}" \
+ && wget -q https://github.com/Dockbit/hacher/archive/${RELEASE}.tar.gz -O hacher-${RELEASE}.tar.gz \
+ && tar xf hacher-${RELEASE}.tar.gz \
+ && cd hacher-* \
+ && make install && make build
+
+FROM alpine:latest
+
+COPY --from=0 /go/bin/hacher-* /hacher
+ENTRYPOINT ["/hacher"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Install [Golang](https://golang.org/doc/install) and:
 * ```HACHER_PATH``` - The path where cached artifacts will be stored.
 * ```HACHER_KEEP``` - The number of caches to keep, defaults to ```3```. You probably won't need more, since it's only useful if someone reverts the dependency file, hence cache could be reused.
 
+### Building in Docker
+
+You can use the [Dockerfile](./Dockerfile) to download and install the hacher binary inside a Docker image. This is handy in case you don't have the Go environment setup locally.
+
+Specifying the [version](https://github.com/Dockbit/hacher/releases) to install is available via the `RELEASE` Docker build argument.
+
+```docker build --tag hacher --build-arg RELEASE=v0.1.0 .```
+
 ## Usage
 
 Let's say you wanted to speed up ```npm install``` during your CI builds, so you could:
@@ -28,6 +36,18 @@ Let's say you wanted to speed up ```npm install``` during your CI builds, so you
 To get more help:
 
     hacher --help
+
+### Running in Docker
+
+If you previously baked hacher in a Docker image, you can run it by exposing the files to be cached as Docker volumes to the container.
+
+```
+docker run --volume $PWD:/source \
+           --volume $PWD/hacher_cache:/cache  \
+           --env HACHER_PATH=/cache \
+           --workdir /source \
+           hacher set -k node_modules -f package.json ./node_modules
+```
 
 ## ToDo
 


### PR DESCRIPTION
This adds a Dockerfile that utilizes Docker build arguments as well as multi-stage builds for building the hacher binary and using it inside a container.

Readme has been modified accordingly to show both building and using the image.